### PR TITLE
use tensorflow.compat.v1 if we are using v2

### DIFF
--- a/faced/detector.py
+++ b/faced/detector.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 import cv2
 import numpy as np
 import os


### PR DESCRIPTION
This is the sticky-plaster fix proposed in #27 

I have a similar patch monkey-patched into my local venv's site_packages, so I thought I might as well contribute it upstream.

This should also survive if the installed version of tensorflow is v1.